### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ module.exports = function(eleventyConfig) {
 };
 ```
 
-After your upgrade is complete and you’ll removed all of the violations/warnings from your output, delete the plugin from your `package.json` and `.eleventy.js` configuration file.
+After your upgrade is complete and you’ve removed all of the violations/warnings from your output, delete the plugin from your `package.json` and `.eleventy.js` configuration file.
 
 ## Example demo
 


### PR DESCRIPTION
Changed `you'll` -> `you've`. Cheers!

Edit: Not sure why it is saying line 39 changed.

```diff
- -->
+ -->
```

Thought it was an extra new line but I am unable see any difference.