### PR TITLE
Clarify instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ The major version of this plugin will always match the major version of Eleventy
 
 ## Usage
 
-Install from npm:
+Update Eleventy _before_ using this plugin, by changing the major version in your `package.json` to something like `"^2.0"`
+and then using `npm update @11ty/eleventy -g` (to upgrade the eleventy global) or `npm update @11ty/eleventy --save-dev` (to upgrade your local project version).
+
+Then, install this plugin from npm:
 
 ```bash
 npm install @11ty/eleventy-upgrade-help@2
@@ -27,7 +30,11 @@ module.exports = function(eleventyConfig) {
 };
 ```
 
-After your upgrade is complete and you’ve removed all of the violations/warnings from your output, delete the plugin from your `package.json` and `.eleventy.js` configuration file.
+Run your usual build command (e.g. `npm run build`) and pay attention to the output.
+Address any violations and warnings. 
+Once you’ve removed all of the violations/warnings from your output, 
+run `npm uninstall @11ty/eleventy-upgrade-help` to remove the plugin 
+and delete its code from your Eleventy configuration file.
 
 ## Example demo
 


### PR DESCRIPTION
- Made it clear that Eleventy needs to be upgraded **before** running this plugin. That was not clear to me at first, I thought the plugin itself would upgrade it, or it would tell me if it's safe to upgrade.
- Added instructions on how to get output from this plugin (running the usual build command), and clarified when exactly to remove it
- Removing the plugin from `package.json` doesn't remove it from `node_modules`, whereas `npm uninstall` does.